### PR TITLE
Update to 2.1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: generic
 
 os: osx
+osx_image: beta-xcode6.1
 
 env:
   matrix:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="2.1.9" %}
+{% set version="2.1.10" %}
 
 package:
   name: pyparsing
@@ -7,7 +7,7 @@ package:
 source:
   fn: pyparsing-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/pyparsing/pyparsing-{{ version }}.tar.gz
-  sha256: 93326f5490bcfe7069806ff342692e75f72529cfa82f20683b5fceeb5d4a7fc2
+  sha256: 811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188
 
 build:
   number: 0


### PR DESCRIPTION
```
Version 2.1.10 - October, 2016
-------------------------------
- Fixed bug in reporting named parse results for ZeroOrMore
  expressions, thanks Ethan Nash for reporting this!

- Fixed behavior of LineStart to be much more predictable.
  LineStart can now be used to detect if the next parse position
  is col 1, factoring in potential leading whitespace (which would
  cause LineStart to fail). Also fixed a bug in col, which is
  used in LineStart, where '\n's were erroneously considered to
  be column 1.

- Added support for multiline test strings in runTests.

- Fixed bug in ParseResults.dump when keys were not strings.
  Also changed display of string values to show them in quotes,
  to help distinguish parsed numeric strings from parsed integers
  that have been converted to Python ints.
```