### PR TITLE
bump to python>=3.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,17 +9,17 @@ source:
   sha256: cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.9
     - pip
-    - flit-core
+    - flit-core >=3.2,<4
   run:
-    - python >=3.6
+    - python >=3.9
 
 test:
   imports:


### PR DESCRIPTION
## Description

Fixes #48

## Notes for Reviewers

If reviewers are open to this change, I'll also submit a repodata patch. Similar to this pair of PRs:

* https://github.com/conda-forge/python-graphviz-feedstock/pull/56
* https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/868

For context... this was discovered because we still support Python 3.8 in LightGBM (https://github.com/microsoft/LightGBM), and `pyparsing` is a direct `run` dependency of `matplotlib-base` ([code link](https://github.com/conda-forge/matplotlib-feedstock/blob/d22b1c7baa0585c566e09f7167dfa3d539135b67/recipe/meta.yaml#L70))

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.